### PR TITLE
Add ssh_key_exclusive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Role to manage users on a system.
   specified for the user.
 * users_create_homedirs (default: true) - create home directories for new
   users. Set this to false if you manage home directories separately.
+* users_ssh_key_exclusive (default: false) - Whether to remove all other
+  non-specified keys from the authorized_keys file.
 * authorized_keys_file (default: .ssh/authorized_keys) - Set this if the
   ssh server is configured to use a non standard authorized keys file.
 
@@ -51,6 +53,8 @@ In addition, the following items are optional for each user:
 * shell - The user's shell. This defaults to /bin/bash. The default is
   configurable using the users_default_shell variable if you want to give all
   users the same shell, but it is different than /bin/bash.
+* ssh_key_exclusive - Whether to remove all other non-specified keys from
+  the authorized_keys file (defaults to users_ssh_key_exclusive).
 
 Example:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ users_default_shell: /bin/bash
 # Create home dirs for new users? Set this to false if you manage home
 # directories in some other way.
 users_create_homedirs: true
+# Whether to remove all other non-specified keys from the
+# authorized_keys file.
+users_ssh_key_exclusive: false
 
 # Lists of users to create and delete
 users: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,13 +34,11 @@
 
 - name: SSH keys
   authorized_key:
-    user: "{{ item.0.username }}"
-    key: "{{ item.1 }}"
-    path: "{{ item.0.home | default('/home/' + item.0.username) }}/{{ authorized_keys_file }}"
-  with_subelements:
-    - "{{ users }}"
-    - ssh_key
-    - skip_missing: yes
+    user: "{{ item.username }}"
+    key: "{{ item.ssh_key | join('\n') }}"
+    path: "{{ item.home | default('/home/' + item.username) }}/{{ authorized_keys_file }}"
+    exclusive: "{{ item.ssh_key_exclusive | default('yes' if users_ssh_key_exclusive else 'no')}}"
+  with_items: "{{users}}"
   tags: ["users", "configuration"]
 
 - name: Setup user profiles


### PR DESCRIPTION
This option enables you to use the exclusive flag from the ansible
authorized_keys plugin to remove all other non-specified keys from the
authorized_keys file.

Using the option users_ssh_key_exclusive controls this global for all
users.

Signed-off-by: Martin Schiller <ms.3headeddevs@gmail.com>